### PR TITLE
Add requirements.txt to .gcloudignore. Fix mount path for generating requirements.txt

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -15,15 +15,4 @@
 
 node_modules
 #!include:.gitignore
-
-# docker/
-# htmlcov/
-# *test.py
-# test*.py
-# deploy.*
-# infra/
-# tests/
-# poetry.lock
-# pyproject.toml
-# docker-compose*
-# Makefile
+!requirements.txt

--- a/.github/workflows/cd-merge.yml
+++ b/.github/workflows/cd-merge.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: "ubuntu-latest"
     environment:
       name: production
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install_hooks:
 	@poetry run pre-commit install --install-hooks
 
 generate_requirements:
-	@poetry export --only=main --without-hashes
+	@poetry export --only=main --without-hashes > requirements.txt
 
 diagrams:
 	@FILES=$$(find ./docs/diagrams -type f -name "*.mmd"); \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker compose run --quiet-pull --no-deps --rm -v $(pwd)/requirements.txt:/app/requirements.txt app make generate_requirements > requirements.txt && (echo "Requirements generated"; cat requirements.txt) || echo "Requirements generating failed"
+docker compose run --quiet-pull --no-deps --rm -v $(pwd):/app app make generate_requirements
 
 gcloud functions deploy check-website-function-http --trigger-http --entry-point=handle_http_request \
 --service-account=check-site-update-function@municipal-fairs.iam.gserviceaccount.com \

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -144,6 +144,7 @@ resource "google_project_iam_member" "functions_deploy_roles" {
     "roles/cloudfunctions.developer",
     "roles/iam.serviceAccountUser",
     "roles/viewer",
+    "roles/run.admin",
   ])
 
   project = var.project_id
@@ -256,7 +257,7 @@ resource "google_cloud_scheduler_job" "hourly_job" {
 
 resource "null_resource" "generate_requirements" {
   provisioner "local-exec" {
-    command = "docker compose run --quiet-pull --no-deps --rm -v $(pwd)/requirements.txt:/app/requirements.txt app make generate_requirements > requirements.txt"
+    command = "docker compose run --quiet-pull --no-deps --rm -v $(pwd):/app app make generate_requirements"
     working_dir = "${path.module}/../"
   }
   triggers = {


### PR DESCRIPTION
1. GCloud forced to skip requirements.txt on deploy, that's why it failed.
  ```
  DEBUG: Running [gcloud.functions.deploy] with arguments: [...]
  ...
  INFO: Using ignore file at [./.gcloudignore].
  DEBUG: Skipping file [./.gcloudignore]
  DEBUG: Skipping file [./requirements.txt]
  ```
  I added `!requirements.txt` to .gloudignore and now it builds function image with proper packages.

2. Add admin role to GitHub Actions Service Account.